### PR TITLE
Make FixedBufRegistry/Pool takes Buffers

### DIFF
--- a/examples/tcp_listener_fixed_buffers.rs
+++ b/examples/tcp_listener_fixed_buffers.rs
@@ -9,6 +9,7 @@ use tokio_uring::{
         BoundedBuf,
     },
     net::{TcpListener, TcpStream},
+    Buffer,
 }; // BoundedBuf for slice method
 
 // A contrived example, where just two fixed buffers are created.
@@ -37,7 +38,9 @@ async fn accept_loop(listen_addr: SocketAddr) {
     );
 
     // Other iterators may be passed to FixedBufRegistry::new also.
-    let buffers = iter::repeat(vec![0; 4096]).take(POOL_SIZE);
+    let buffers = iter::repeat(vec![0; 4096])
+        .take(POOL_SIZE)
+        .map(Buffer::from);
 
     // Register the buffers with the kernel, asserting the syscall passed.
 

--- a/src/buf/fixed/plumbing/pool.rs
+++ b/src/buf/fixed/plumbing/pool.rs
@@ -53,6 +53,7 @@ impl Pool {
         let mut states = Vec::with_capacity(buffers.len());
         let mut free_buf_head_by_cap = HashMap::new();
         for (i, buf) in buffers.iter().enumerate() {
+            debug_assert_eq!(buf.len(), 1);
             let ptr = buf.stable_ptr();
             let len = buf.bytes_init();
             let cap = buf.bytes_total();

--- a/src/buf/fixed/plumbing/registry.rs
+++ b/src/buf/fixed/plumbing/registry.rs
@@ -40,6 +40,7 @@ impl Registry {
         let mut iovecs = Vec::with_capacity(buffers.len());
         let mut states = Vec::with_capacity(buffers.len());
         for buf in buffers.iter() {
+            debug_assert_eq!(buf.len(), 1);
             // Origin buffer will be dropped when Registry is dropped
             let ptr = buf.stable_ptr();
             let len = buf.bytes_init();

--- a/src/buf/fixed/pool.rs
+++ b/src/buf/fixed/pool.rs
@@ -213,6 +213,7 @@ impl FixedBufPool {
 ///
 /// ```should_panic
 /// use tokio_uring::buf::fixed::pool;
+/// use tokio_uring::Buffer;
 /// use std::iter;
 ///
 /// # #[allow(non_snake_case)]
@@ -223,7 +224,7 @@ impl FixedBufPool {
 /// # let BUF_SIZE = 4096;
 ///
 /// tokio_uring::start(async {
-///     let pool = pool::register(iter::repeat(Vec::with_capacity(BUF_SIZE)).take(NUM_BUFFERS))?;
+///     let pool = pool::register(iter::repeat(Vec::<u8>::with_capacity(BUF_SIZE)).take(NUM_BUFFERS).map(Buffer::from))?;
 ///     // ...
 ///     Ok(())
 /// })
@@ -234,6 +235,7 @@ impl FixedBufPool {
 ///
 /// ```
 /// use tokio_uring::buf::fixed::pool;
+/// use tokio_uring::Buffer;
 /// use std::iter;
 ///
 /// # #[allow(non_snake_case)]
@@ -244,7 +246,7 @@ impl FixedBufPool {
 /// # let BUF_SIZE = 4096;
 ///
 /// tokio_uring::start(async {
-///     let pool = pool::register(iter::repeat_with(|| Vec::with_capacity(BUF_SIZE)).take(NUM_BUFFERS))?;
+///     let pool = pool::register(iter::repeat_with(|| Vec::<u8>::with_capacity(BUF_SIZE)).take(NUM_BUFFERS).map(Buffer::from))?;
 ///     // ...
 ///     Ok(())
 /// })
@@ -256,7 +258,7 @@ impl FixedBufPool {
 /// If a collection of buffers is currently registered in the context
 /// of the `tokio-uring` runtime this call is made in, the function returns
 /// an error.
-pub fn register(bufs: impl Iterator<Item = Vec<u8>>) -> io::Result<FixedBufPool> {
+pub fn register(bufs: impl Iterator<Item = Buffer>) -> io::Result<FixedBufPool> {
     let pool_inner = plumbing::Pool::new(bufs);
     CONTEXT.with(|x| {
         x.handle()

--- a/src/buf/fixed/registry.rs
+++ b/src/buf/fixed/registry.rs
@@ -106,6 +106,7 @@ impl FixedBufRegistry {
 ///
 /// ```should_panic
 /// use tokio_uring::buf::fixed::registry;
+/// use tokio_uring::Buffer;
 /// use std::iter;
 ///
 /// # #[allow(non_snake_case)]
@@ -116,7 +117,7 @@ impl FixedBufRegistry {
 /// # let BUF_SIZE = 4096;
 ///
 /// tokio_uring::start(async {
-///     let registry = registry::register(iter::repeat(Vec::with_capacity(BUF_SIZE)).take(NUM_BUFFERS))?;
+///     let registry = registry::register(iter::repeat(Vec::<u8>::with_capacity(BUF_SIZE)).take(NUM_BUFFERS).map(Buffer::from))?;
 ///     // ...
 ///     Ok(())
 /// })
@@ -127,6 +128,7 @@ impl FixedBufRegistry {
 ///
 /// ```
 /// use tokio_uring::buf::fixed::registry;
+/// use tokio_uring::Buffer;
 /// use std::iter;
 ///
 /// # #[allow(non_snake_case)]
@@ -137,7 +139,7 @@ impl FixedBufRegistry {
 /// # let BUF_SIZE = 4096;
 ///
 /// tokio_uring::start(async {
-///     let registry = registry::register(iter::repeat_with(|| Vec::with_capacity(BUF_SIZE)).take(NUM_BUFFERS))?;
+///     let registry = registry::register(iter::repeat_with(|| Vec::<u8>::with_capacity(BUF_SIZE)).take(NUM_BUFFERS).map(Buffer::from))?;
 ///     // ...
 ///     Ok(())
 /// })
@@ -149,7 +151,7 @@ impl FixedBufRegistry {
 /// If a collection of buffers is currently registered in the context
 /// of the `tokio-uring` runtime this call is made in, the function returns
 /// an error.
-pub fn register(bufs: impl Iterator<Item = Vec<u8>>) -> io::Result<FixedBufRegistry> {
+pub fn register(bufs: impl Iterator<Item = Buffer>) -> io::Result<FixedBufRegistry> {
     let registry_inner = plumbing::Registry::new(bufs);
     CONTEXT.with(|x| {
         x.handle()

--- a/src/fs/file.rs
+++ b/src/fs/file.rs
@@ -299,10 +299,11 @@ impl File {
     /// use tokio_uring::fs::File;
     /// use tokio_uring::buf::fixed::registry;
     /// use tokio_uring::buf::BoundedBuf;
+    /// use tokio_uring::Buffer;
     /// use std::iter;
     ///
     /// tokio_uring::start(async {
-    ///     let registry = registry::register(iter::repeat(vec![0; 10]).take(10))?;
+    ///     let registry = registry::register(iter::repeat(vec![0u8; 10]).take(10).map(Buffer::from))?;
     ///
     ///     let f = File::open("foo.txt").await?;
     ///     let buffer = registry.check_out(2).unwrap();
@@ -396,9 +397,10 @@ impl File {
     /// use tokio_uring::fs::File;
     /// use tokio_uring::buf::fixed::registry;
     /// use tokio_uring::buf::BoundedBuf;
+    /// use tokio_uring::Buffer;
     ///
     /// tokio_uring::start(async {
-    ///     let registry = registry::register(vec![b"some bytes".to_vec()].into_iter())?;
+    ///     let registry = registry::register(vec![b"some bytes".to_vec()].into_iter().map(Buffer::from))?;
     ///
     ///     let file = File::create("foo.txt").await?;
     ///

--- a/tests/fs_file.rs
+++ b/tests/fs_file.rs
@@ -207,9 +207,12 @@ fn read_fixed() {
         let mut tempfile = tempfile();
         tempfile.write_all(HELLO).unwrap();
 
-        let buffers =
-            registry::register(vec![Vec::with_capacity(6), Vec::with_capacity(1024)].into_iter())
-                .unwrap();
+        let buffers = registry::register(
+            vec![Vec::<u8>::with_capacity(6), Vec::with_capacity(1024)]
+                .into_iter()
+                .map(Buffer::from),
+        )
+        .unwrap();
 
         let file = File::open(tempfile.path()).await.unwrap();
 
@@ -236,9 +239,12 @@ fn write_fixed() {
 
         let file = File::create(tempfile.path()).await.unwrap();
 
-        let buffers =
-            registry::register(vec![Vec::with_capacity(6), Vec::with_capacity(1024)].into_iter())
-                .unwrap();
+        let buffers = registry::register(
+            vec![Vec::<u8>::with_capacity(6), Vec::with_capacity(1024)]
+                .into_iter()
+                .map(Buffer::from),
+        )
+        .unwrap();
 
         let fixed_buf = buffers.check_out(0).unwrap();
         let mut buf = fixed_buf;


### PR DESCRIPTION
`FixedBufRegistry/Pool`이 `Vec<u8>` 대신 `Buffer`를 받게 수정합니다.

기존처럼 `Vec<u8>`을 사용하면 mmap을 이용해 hugepage에 할당된 buffer를 unmap할 수 있는 타이밍이 없습니다.