### PR TITLE
fix: consume iovec vector read from ManuallyDrop's pointer

### DIFF
--- a/src/buf/mod.rs
+++ b/src/buf/mod.rs
@@ -130,7 +130,7 @@ impl Buffer {
             let user_data = Box::from_raw(this.user_data as *mut B::UserData);
             let (ptrs, len) = this
                 .iovec
-                .iter()
+                .into_iter()
                 .map(|iovec| (iovec.iov_base as *mut u8, iovec.iov_len))
                 .collect();
 


### PR DESCRIPTION
manually drop 으로 읽어온 vector를 into_iter로 consume하여 memory leak 제거